### PR TITLE
Fix navigation button markup in maintenance Razor pages

### DIFF
--- a/Pages/Bakim/Detay.razor
+++ b/Pages/Bakim/Detay.razor
@@ -33,7 +33,7 @@ else if (maintenance is null)
 {
     <div class="alert alert-warning">
         İstenen bakım kaydı bulunamadı.
-        <button class="btn btn-sm btn-outline-secondary ms-2" @onclick="() => Navigation.NavigateTo("/bakim")">Listeye Dön</button>
+        <button class="btn btn-sm btn-outline-secondary ms-2" @onclick="() => Navigation.NavigateTo(\"/bakim\")">Listeye Dön</button>
     </div>
 }
 else
@@ -286,7 +286,7 @@ else
                         <button class="btn btn-outline-success" disabled="@(maintenance.Status == BakimDurumu.MaintenanceCompleted)" @onclick="() => UpdateStatusAsync(BakimDurumu.MaintenanceCompleted)">
                             <i class="bi bi-check-circle me-1"></i> Bakımı Tamamla
                         </button>
-                        <button class="btn btn-outline-secondary" @onclick="() => Navigation.NavigateTo("/bakim")">
+                        <button class="btn btn-outline-secondary" @onclick="() => Navigation.NavigateTo(\"/bakim\")">
                             <i class="bi bi-arrow-left me-1"></i> Listeye Dön
                         </button>
                     </div>

--- a/Pages/Bakim/Index.razor
+++ b/Pages/Bakim/Index.razor
@@ -20,7 +20,7 @@
             <i class="bi bi-arrow-clockwise me-1"></i> Yenile
         </button>
     </div>
-    <button class="btn btn-primary" @onclick="() => Navigation.NavigateTo("/bakim/yeni")">
+    <button class="btn btn-primary" @onclick="() => Navigation.NavigateTo(\"/bakim/yeni\")">
         <i class="bi bi-plus-circle me-1"></i> Yeni Bakım/Arıza Kaydı
     </button>
 </div>
@@ -121,7 +121,7 @@ else
                         <td>@(maintenance.EndDate.HasValue ? maintenance.EndDate.Value.ToLocalTime().ToString("dd.MM.yyyy") : "-")</td>
                         <td class="text-end">@maintenance.TotalCost.ToString("C2", CultureInfo.GetCultureInfo("tr-TR"))</td>
                         <td class="text-end">
-                            <button class="btn btn-sm btn-outline-primary" @onclick="() => Navigation.NavigateTo($"/bakim/detay/{maintenance.Id}")">
+                            <button class="btn btn-sm btn-outline-primary" @onclick="() => Navigation.NavigateTo($\"/bakim/detay/{maintenance.Id}\")">
                                 <i class="bi bi-search"></i> Detay
                             </button>
                         </td>

--- a/Pages/Bakim/Yeni.razor
+++ b/Pages/Bakim/Yeni.razor
@@ -81,7 +81,7 @@
             }
             Kaydet
         </button>
-        <button class="btn btn-secondary" type="button" @onclick="() => Navigation.NavigateTo("/bakim")">İptal</button>
+        <button class="btn btn-secondary" type="button" @onclick="() => Navigation.NavigateTo(\"/bakim\")">İptal</button>
     </div>
 </EditForm>
 


### PR DESCRIPTION
## Summary
- escape navigation URLs inside maintenance Razor page buttons so the generated markup parses correctly

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e74b77858c8330b5057e67278ebf34