### PR TITLE
Fix Razor navigation handlers and fault code loop naming

### DIFF
--- a/Pages/Bakim/Detay.razor
+++ b/Pages/Bakim/Detay.razor
@@ -33,7 +33,7 @@ else if (maintenance is null)
 {
     <div class="alert alert-warning">
         İstenen bakım kaydı bulunamadı.
-        <button class="btn btn-sm btn-outline-secondary ms-2" @onclick="() => Navigation.NavigateTo("/bakim")">Listeye Dön</button>
+        <button class="btn btn-sm btn-outline-secondary ms-2" @onclick="NavigateToMaintenanceList">Listeye Dön</button>
     </div>
 }
 else
@@ -286,7 +286,7 @@ else
                         <button class="btn btn-outline-success" disabled="@(maintenance.Status == BakimDurumu.MaintenanceCompleted)" @onclick="() => UpdateStatusAsync(BakimDurumu.MaintenanceCompleted)">
                             <i class="bi bi-check-circle me-1"></i> Bakımı Tamamla
                         </button>
-                        <button class="btn btn-outline-secondary" @onclick="() => Navigation.NavigateTo("/bakim")">
+                        <button class="btn btn-outline-secondary" @onclick="NavigateToMaintenanceList">
                             <i class="bi bi-arrow-left me-1"></i> Listeye Dön
                         </button>
                     </div>
@@ -375,6 +375,11 @@ else
         await MaintenanceService.UpdateStatusAsync(Id, status, userId);
         await RefreshMaintenanceAsync();
         successMessage = "Durum güncellendi.";
+    }
+
+    private void NavigateToMaintenanceList()
+    {
+        Navigation.NavigateTo("/bakim");
     }
 
     private async Task AddPartAsync()

--- a/Pages/Bakim/Index.razor
+++ b/Pages/Bakim/Index.razor
@@ -20,7 +20,7 @@
             <i class="bi bi-arrow-clockwise me-1"></i> Yenile
         </button>
     </div>
-    <button class="btn btn-primary" @onclick="() => Navigation.NavigateTo("/bakim/yeni")">
+    <button class="btn btn-primary" @onclick="NavigateToNewMaintenance">
         <i class="bi bi-plus-circle me-1"></i> Yeni Bakım/Arıza Kaydı
     </button>
 </div>
@@ -121,7 +121,7 @@ else
                         <td>@(maintenance.EndDate.HasValue ? maintenance.EndDate.Value.ToLocalTime().ToString("dd.MM.yyyy") : "-")</td>
                         <td class="text-end">@maintenance.TotalCost.ToString("C2", CultureInfo.GetCultureInfo("tr-TR"))</td>
                         <td class="text-end">
-                            <button class="btn btn-sm btn-outline-primary" @onclick="() => Navigation.NavigateTo($"/bakim/detay/{maintenance.Id}")">
+                            <button class="btn btn-sm btn-outline-primary" @onclick="@(() => NavigateToMaintenanceDetail(maintenance.Id))">
                                 <i class="bi bi-search"></i> Detay
                             </button>
                         </td>
@@ -145,6 +145,16 @@ else
     protected override async Task OnInitializedAsync()
     {
         await LoadMaintenancesAsync();
+    }
+
+    private void NavigateToNewMaintenance()
+    {
+        Navigation.NavigateTo("/bakim/yeni");
+    }
+
+    private void NavigateToMaintenanceDetail(int id)
+    {
+        Navigation.NavigateTo($"/bakim/detay/{id}");
     }
 
     private async Task LoadMaintenancesAsync()

--- a/Pages/Bakim/Yeni.razor
+++ b/Pages/Bakim/Yeni.razor
@@ -81,7 +81,7 @@
             }
             Kaydet
         </button>
-        <button class="btn btn-secondary" type="button" @onclick="() => Navigation.NavigateTo("/bakim")">İptal</button>
+        <button class="btn btn-secondary" type="button" @onclick="NavigateBackToList">İptal</button>
     </div>
 </EditForm>
 
@@ -153,5 +153,10 @@
         {
             isSaving = false;
         }
+    }
+
+    private void NavigateBackToList()
+    {
+        Navigation.NavigateTo("/bakim");
     }
 }

--- a/Pages/Tanimlar/ArizaKodlari.razor
+++ b/Pages/Tanimlar/ArizaKodlari.razor
@@ -72,15 +72,15 @@
                 <tbody>
                     @if (faultCodes.Any())
                     {
-                        @foreach (FaultCode code in faultCodes)
+                        @foreach (FaultCode faultCode in faultCodes)
                         {
-                            <tr class="@(code.IsActive ? string.Empty : "table-secondary")">
-                                <td><strong>@code.Code</strong></td>
-                                <td>@code.Name</td>
-                                <td>@code.Category</td>
-                                <td>@code.Description</td>
+                            <tr class="@(faultCode.IsActive ? string.Empty : "table-secondary")">
+                                <td><strong>@faultCode.Code</strong></td>
+                                <td>@faultCode.Name</td>
+                                <td>@faultCode.Category</td>
+                                <td>@faultCode.Description</td>
                                 <td>
-                                    @if (code.IsActive)
+                                    @if (faultCode.IsActive)
                                     {
                                         <span class="badge bg-success">Aktif</span>
                                     }
@@ -90,8 +90,8 @@
                                     }
                                 </td>
                                 <td class="text-end">
-                                    <button class="btn btn-sm @(code.IsActive ? "btn-outline-danger" : "btn-outline-success")" @onclick="() => ToggleStatusAsync(code)">
-                                        @if (code.IsActive)
+                                    <button class="btn btn-sm @(faultCode.IsActive ? "btn-outline-danger" : "btn-outline-success")" @onclick="() => ToggleStatusAsync(faultCode)">
+                                        @if (faultCode.IsActive)
                                         {
                                             <span><i class="bi bi-x-circle"></i> Pasifleştir</span>
                                         }
@@ -168,12 +168,12 @@
         }
     }
 
-    private async Task ToggleStatusAsync(FaultCode code)
+    private async Task ToggleStatusAsync(FaultCode faultCode)
     {
         errorMessage = null;
         successMessage = null;
 
-        await MaintenanceService.UpdateFaultCodeStatusAsync(code.Id, !code.IsActive);
+        await MaintenanceService.UpdateFaultCodeStatusAsync(faultCode.Id, !faultCode.IsActive);
         await LoadFaultCodesAsync();
     }
 }


### PR DESCRIPTION
## Summary
- update maintenance page navigation buttons to call helper methods so Razor parses the markup without escaping issues
- rename the fault code table iteration variable to avoid Razor interpreting `@code` inside markup

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e74b77858c8330b5057e67278ebf34