### PR TITLE
Fix Razor input components to avoid parsing errors

### DIFF
--- a/Pages/Bakim/Detay.razor
+++ b/Pages/Bakim/Detay.razor
@@ -33,7 +33,7 @@ else if (maintenance is null)
 {
     <div class="alert alert-warning">
         İstenen bakım kaydı bulunamadı.
-        <button class="btn btn-sm btn-outline-secondary ms-2" @onclick="() => Navigation.NavigateTo("/bakim")">Listeye Dön</button>
+        <button class="btn btn-sm btn-outline-secondary ms-2" @onclick="NavigateToMaintenanceList">Listeye Dön</button>
     </div>
 }
 else
@@ -286,7 +286,7 @@ else
                         <button class="btn btn-outline-success" disabled="@(maintenance.Status == BakimDurumu.MaintenanceCompleted)" @onclick="() => UpdateStatusAsync(BakimDurumu.MaintenanceCompleted)">
                             <i class="bi bi-check-circle me-1"></i> Bakımı Tamamla
                         </button>
-                        <button class="btn btn-outline-secondary" @onclick="() => Navigation.NavigateTo("/bakim")">
+                        <button class="btn btn-outline-secondary" @onclick="NavigateToMaintenanceList">
                             <i class="bi bi-arrow-left me-1"></i> Listeye Dön
                         </button>
                     </div>
@@ -375,6 +375,11 @@ else
         await MaintenanceService.UpdateStatusAsync(Id, status, userId);
         await RefreshMaintenanceAsync();
         successMessage = "Durum güncellendi.";
+    }
+
+    private void NavigateToMaintenanceList()
+    {
+        Navigation.NavigateTo("/bakim");
     }
 
     private async Task AddPartAsync()

--- a/Pages/Bakim/Index.razor
+++ b/Pages/Bakim/Index.razor
@@ -20,7 +20,7 @@
             <i class="bi bi-arrow-clockwise me-1"></i> Yenile
         </button>
     </div>
-    <button class="btn btn-primary" @onclick="() => Navigation.NavigateTo("/bakim/yeni")">
+    <button class="btn btn-primary" @onclick="NavigateToNewMaintenance">
         <i class="bi bi-plus-circle me-1"></i> Yeni Bakım/Arıza Kaydı
     </button>
 </div>
@@ -121,7 +121,7 @@ else
                         <td>@(maintenance.EndDate.HasValue ? maintenance.EndDate.Value.ToLocalTime().ToString("dd.MM.yyyy") : "-")</td>
                         <td class="text-end">@maintenance.TotalCost.ToString("C2", CultureInfo.GetCultureInfo("tr-TR"))</td>
                         <td class="text-end">
-                            <button class="btn btn-sm btn-outline-primary" @onclick="() => Navigation.NavigateTo($"/bakim/detay/{maintenance.Id}")">
+                            <button class="btn btn-sm btn-outline-primary" @onclick="@(() => NavigateToMaintenanceDetail(maintenance.Id))">
                                 <i class="bi bi-search"></i> Detay
                             </button>
                         </td>
@@ -145,6 +145,16 @@ else
     protected override async Task OnInitializedAsync()
     {
         await LoadMaintenancesAsync();
+    }
+
+    private void NavigateToNewMaintenance()
+    {
+        Navigation.NavigateTo("/bakim/yeni");
+    }
+
+    private void NavigateToMaintenanceDetail(int id)
+    {
+        Navigation.NavigateTo($"/bakim/detay/{id}");
     }
 
     private async Task LoadMaintenancesAsync()

--- a/Pages/Bakim/Yeni.razor
+++ b/Pages/Bakim/Yeni.razor
@@ -81,7 +81,7 @@
             }
             Kaydet
         </button>
-        <button class="btn btn-secondary" type="button" @onclick="() => Navigation.NavigateTo("/bakim")">İptal</button>
+        <button class="btn btn-secondary" type="button" @onclick="NavigateBackToList">İptal</button>
     </div>
 </EditForm>
 
@@ -153,5 +153,10 @@
         {
             isSaving = false;
         }
+    }
+
+    private void NavigateBackToList()
+    {
+        Navigation.NavigateTo("/bakim");
     }
 }

--- a/Pages/Hareketler/History.razor
+++ b/Pages/Hareketler/History.razor
@@ -14,7 +14,7 @@
         </div>
         <div class="col-md-2">
             <label class="form-label">Varlık ID</label>
-            <InputNumber class="form-control" @bind-Value="entityId" placeholder="ID" />
+            <InputNumber<int> class="form-control" @bind-Value="entityId" placeholder="ID" />
         </div>
         <div class="col-md-3 d-flex align-items-end">
             <button class="btn btn-primary" @onclick="LoadHistory">Geçmişi Getir</button>

--- a/Pages/Satinalma/Bagimsiz.razor
+++ b/Pages/Satinalma/Bagimsiz.razor
@@ -100,10 +100,10 @@
                 </InputSelect>
             </div>
             <div class="col-md-1">
-                <InputNumber class="form-control" @bind-Value="newQuantity" placeholder="Miktar" />
+                <InputNumber<int> class="form-control" @bind-Value="newQuantity" placeholder="Miktar" />
             </div>
             <div class="col-md-2">
-                <InputNumber class="form-control" @bind-Value="newUnitPrice" placeholder="Birim Fiyat" />
+                <InputNumber<decimal> class="form-control" @bind-Value="newUnitPrice" placeholder="Birim Fiyat" />
             </div>
             <div class="col-md-2">
                 <InputSelect class="form-select" @bind-Value="newCurrency">

--- a/Pages/Stok/Cikis.razor
+++ b/Pages/Stok/Cikis.razor
@@ -75,7 +75,7 @@ else
 
             <div class="col-md-3">
                 <label class="form-label">Miktar</label>
-                <InputNumber class="form-control" @bind-Value="model.Quantity" min="1" />
+                <InputNumber<int> class="form-control" @bind-Value="model.Quantity" min="1" />
                 <ValidationMessage For="() => model.Quantity" />
             </div>
 
@@ -92,22 +92,22 @@ else
 
             <div class="col-md-3">
                 <label class="form-label">Talep Kalemi (opsiyonel)</label>
-                <InputNumber class="form-control" @bind-Value="model.RequestItemId" />
+                <InputNumber<int?> class="form-control" @bind-Value="model.RequestItemId" />
             </div>
 
             <div class="col-md-3">
                 <label class="form-label">Varlık / Araç (opsiyonel)</label>
-                <InputNumber class="form-control" @bind-Value="model.AssetId" />
+                <InputNumber<int?> class="form-control" @bind-Value="model.AssetId" />
             </div>
 
             <div class="col-md-3">
                 <label class="form-label">KM (opsiyonel)</label>
-                <InputNumber class="form-control" @bind-Value="model.Km" />
+                <InputNumber<int?> class="form-control" @bind-Value="model.Km" />
             </div>
 
             <div class="col-md-3">
                 <label class="form-label">Çalışma Saati (opsiyonel)</label>
-                <InputNumber class="form-control" @bind-Value="model.HourMeter" />
+                <InputNumber<int?> class="form-control" @bind-Value="model.HourMeter" />
             </div>
 
             <div class="col-12">

--- a/Pages/Stok/Hareketler.razor
+++ b/Pages/Stok/Hareketler.razor
@@ -15,11 +15,11 @@
         <div class="row g-3 align-items-end">
             <div class="col-md-3">
                 <label class="form-label">Başlangıç Tarihi</label>
-                <InputDate class="form-control" @bind-Value="filterStart" />
+                <InputDate<DateTime?> class="form-control" @bind-Value="filterStart" />
             </div>
             <div class="col-md-3">
                 <label class="form-label">Bitiş Tarihi</label>
-                <InputDate class="form-control" @bind-Value="filterEnd" />
+                <InputDate<DateTime?> class="form-control" @bind-Value="filterEnd" />
             </div>
             <div class="col-md-3">
                 <label class="form-label">Hareket Türü</label>

--- a/Pages/Stok/Transfer.razor
+++ b/Pages/Stok/Transfer.razor
@@ -91,7 +91,7 @@ else
 
             <div class="col-md-3">
                 <label class="form-label">Miktar</label>
-                <InputNumber class="form-control" @bind-Value="model.Quantity" min="1" />
+                <InputNumber<int> class="form-control" @bind-Value="model.Quantity" min="1" />
                 <ValidationMessage For="() => model.Quantity" />
             </div>
 

--- a/Pages/Talep/Yeni.razor
+++ b/Pages/Talep/Yeni.razor
@@ -120,7 +120,7 @@
             <!-- Miktar -->
             <div class="col-md-3">
                 <label class="form-label">Miktar</label>
-                <InputNumber class="form-control"
+                <InputNumber<int> class="form-control"
                              @bind-Value="newItemQuantity"
                              placeholder="@GetQuantityPlaceholder()" />
             </div>

--- a/Pages/Tanimlar/ArizaKodlari.razor
+++ b/Pages/Tanimlar/ArizaKodlari.razor
@@ -72,15 +72,15 @@
                 <tbody>
                     @if (faultCodes.Any())
                     {
-                        @foreach (FaultCode code in faultCodes)
+                        @foreach (FaultCode faultCode in faultCodes)
                         {
-                            <tr class="@(code.IsActive ? string.Empty : "table-secondary")">
-                                <td><strong>@code.Code</strong></td>
-                                <td>@code.Name</td>
-                                <td>@code.Category</td>
-                                <td>@code.Description</td>
+                            <tr class="@(faultCode.IsActive ? string.Empty : "table-secondary")">
+                                <td><strong>@faultCode.Code</strong></td>
+                                <td>@faultCode.Name</td>
+                                <td>@faultCode.Category</td>
+                                <td>@faultCode.Description</td>
                                 <td>
-                                    @if (code.IsActive)
+                                    @if (faultCode.IsActive)
                                     {
                                         <span class="badge bg-success">Aktif</span>
                                     }
@@ -90,8 +90,8 @@
                                     }
                                 </td>
                                 <td class="text-end">
-                                    <button class="btn btn-sm @(code.IsActive ? "btn-outline-danger" : "btn-outline-success")" @onclick="() => ToggleStatusAsync(code)">
-                                        @if (code.IsActive)
+                                    <button class="btn btn-sm @(faultCode.IsActive ? "btn-outline-danger" : "btn-outline-success")" @onclick="() => ToggleStatusAsync(faultCode)">
+                                        @if (faultCode.IsActive)
                                         {
                                             <span><i class="bi bi-x-circle"></i> Pasifleştir</span>
                                         }
@@ -168,12 +168,12 @@
         }
     }
 
-    private async Task ToggleStatusAsync(FaultCode code)
+    private async Task ToggleStatusAsync(FaultCode faultCode)
     {
         errorMessage = null;
         successMessage = null;
 
-        await MaintenanceService.UpdateFaultCodeStatusAsync(code.Id, !code.IsActive);
+        await MaintenanceService.UpdateFaultCodeStatusAsync(faultCode.Id, !faultCode.IsActive);
         await LoadFaultCodesAsync();
     }
 }

--- a/Pages/Tanimlar/Urun.razor
+++ b/Pages/Tanimlar/Urun.razor
@@ -108,7 +108,7 @@
 
     <div class="mb-3">
         <label>Min. Stok</label>
-        <InputNumber class="form-control" @bind-Value="model.MinStock" />
+        <InputNumber<int?> class="form-control" @bind-Value="model.MinStock" />
     </div>
 
     <div class="form-check mb-3">

--- a/Pages/Yakit/Cikis.razor
+++ b/Pages/Yakit/Cikis.razor
@@ -55,7 +55,7 @@ else
 
             <div class="col-md-2">
                 <label class="form-label">Miktar</label>
-                <InputNumber class="form-control" @bind-Value="model.Quantity" />
+                <InputNumber<int> class="form-control" @bind-Value="model.Quantity" />
             </div>
 
             <div class="col-md-2">
@@ -76,12 +76,12 @@ else
 
             <div class="col-md-2">
                 <label class="form-label">KM</label>
-                <InputNumber class="form-control" @bind-Value="model.Km" />
+                <InputNumber<int?> class="form-control" @bind-Value="model.Km" />
             </div>
 
             <div class="col-md-2">
                 <label class="form-label">Saat</label>
-                <InputNumber class="form-control" @bind-Value="model.HourMeter" />
+                <InputNumber<int?> class="form-control" @bind-Value="model.HourMeter" />
             </div>
 
             <div class="col-md-4">

--- a/Pages/Yakit/Giris.razor
+++ b/Pages/Yakit/Giris.razor
@@ -55,7 +55,7 @@ else
 
             <div class="col-md-2">
                 <label class="form-label">Miktar</label>
-                <InputNumber class="form-control" @bind-Value="model.Quantity" />
+                <InputNumber<int> class="form-control" @bind-Value="model.Quantity" />
             </div>
 
             <div class="col-md-2">


### PR DESCRIPTION
## Summary
- specify TValue for InputDate filters on stock movement page to satisfy Razor parsing
- add explicit generic arguments to InputNumber components across stock, purchasing, fuel, and request forms so type inference succeeds

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e74b77858c8330b5057e67278ebf34